### PR TITLE
Validate history before building anchors

### DIFF
--- a/RLasso.R
+++ b/RLasso.R
@@ -73,7 +73,12 @@ build_xy_paper <- function(dados, yname, h, p_y=4, x_lags=4, pc_fit) {
   colnames(PC) <- paste0("PC", 1:4)
   
   maxdrop <- max(p_y, x_lags)
-  anchors <- maxdrop:(nrow(dados) - h)  # indices of t
+  last_anchor <- nrow(dados) - h
+  if (last_anchor < maxdrop) {
+    stop("Not enough history for horizon h=", h,
+         " (need anchor >= ", maxdrop, ", have last_anchor = ", last_anchor, ").")
+  }
+  anchors <- seq.int(maxdrop, last_anchor)  # indices of t
   
   X <- cbind(ylag, Xlags, PC)[anchors, , drop = FALSE]
   rownames(X) <- dates[anchors]

--- a/adaelnet.R
+++ b/adaelnet.R
@@ -77,7 +77,12 @@ build_xy_paper <- function(dados, yname, h, p_y=4, x_lags=4, pc_fit) {
   colnames(PC) <- paste0("PC", 1:4)
   
   maxdrop <- max(p_y, x_lags)
-  anchors <- maxdrop:(nrow(dados) - h)  # indices of t
+  last_anchor <- nrow(dados) - h
+  if (last_anchor < maxdrop) {
+    stop("Not enough history for horizon h=", h,
+         " (need anchor >= ", maxdrop, ", have last_anchor = ", last_anchor, ").")
+  }
+  anchors <- seq.int(maxdrop, last_anchor)  # indices of t
   X <- cbind(ylag, Xlags, PC)[anchors, , drop = FALSE]
   rownames(X) <- dates[anchors]
   y_target <- y[anchors + h]; names(y_target) <- dates[anchors + h]

--- a/adalasso.R
+++ b/adalasso.R
@@ -80,7 +80,12 @@ build_xy_paper <- function(dados, yname, h, p_y=4, x_lags=4, pc_fit) {
   colnames(PC) <- paste0("PC", 1:4)
   
   maxdrop <- max(p_y, x_lags)
-  anchors <- maxdrop:(nrow(dados) - h)  # indices of t (issue-time anchors)
+  last_anchor <- nrow(dados) - h
+  if (last_anchor < maxdrop) {
+    stop("Not enough history for horizon h=", h,
+         " (need anchor >= ", maxdrop, ", have last_anchor = ", last_anchor, ").")
+  }
+  anchors <- seq.int(maxdrop, last_anchor)  # indices of t (issue-time anchors)
   X <- cbind(ylag, Xlags, PC)[anchors, , drop = FALSE]
   rownames(X) <- dates[anchors]
   

--- a/adalassorf.R
+++ b/adalassorf.R
@@ -128,7 +128,12 @@ build_xy_paper <- function(dados, yname, h, p_y=4, x_lags=4, pc_fit) {
   colnames(PC) <- paste0("PC", 1:4)
   
   maxdrop <- max(p_y, x_lags)
-  anchors <- maxdrop:(nrow(dados) - h)  # indices of t
+  last_anchor <- nrow(dados) - h
+  if (last_anchor < maxdrop) {
+    stop("Not enough history for horizon h=", h,
+         " (need anchor >= ", maxdrop, ", have last_anchor = ", last_anchor, ").")
+  }
+  anchors <- seq.int(maxdrop, last_anchor)  # indices of t
   
   X <- cbind(ylag, Xlags, PC)[anchors, , drop = FALSE]
   rownames(X) <- dates[anchors]

--- a/ar.R
+++ b/ar.R
@@ -66,7 +66,12 @@ build_xy_paper <- function(dados, yname, h, p_y=4, x_lags=4, pc_fit) {
   colnames(PC) <- paste0("PC", 1:4)
   
   maxdrop <- max(p_y, x_lags)
-  anchors <- maxdrop:(nrow(dados) - h)  # indices of t
+  last_anchor <- nrow(dados) - h
+  if (last_anchor < maxdrop) {
+    stop("Not enough history for horizon h=", h,
+         " (need anchor >= ", maxdrop, ", have last_anchor = ", last_anchor, ").")
+  }
+  anchors <- seq.int(maxdrop, last_anchor)  # indices of t
   
   X <- cbind(ylag, Xlags, PC)[anchors, , drop = FALSE]
   rownames(X) <- dates[anchors]

--- a/bagging.R
+++ b/bagging.R
@@ -70,7 +70,12 @@ build_xy_paper <- function(dados, yname, h, p_y=4, x_lags=4, pc_fit) {
   colnames(PC) <- paste0("PC", 1:4)
   
   maxdrop <- max(p_y, x_lags)
-  anchors <- maxdrop:(nrow(dados) - h)  # indices of t
+  last_anchor <- nrow(dados) - h
+  if (last_anchor < maxdrop) {
+    stop("Not enough history for horizon h=", h,
+         " (need anchor >= ", maxdrop, ", have last_anchor = ", last_anchor, ").")
+  }
+  anchors <- seq.int(maxdrop, last_anchor)  # indices of t
   
   X <- cbind(ylag, Xlags, PC)[anchors, , drop = FALSE]
   rownames(X) <- dates[anchors]

--- a/elnet.R
+++ b/elnet.R
@@ -81,7 +81,12 @@ build_xy_paper <- function(dados, yname, h, p_y=4, x_lags=4, pc_fit) {
   colnames(PC) <- paste0("PC", 1:4)
   
   maxdrop <- max(p_y, x_lags)
-  anchors <- maxdrop:(nrow(dados) - h)  # indices of t
+  last_anchor <- nrow(dados) - h
+  if (last_anchor < maxdrop) {
+    stop("Not enough history for horizon h=", h,
+         " (need anchor >= ", maxdrop, ", have last_anchor = ", last_anchor, ").")
+  }
+  anchors <- seq.int(maxdrop, last_anchor)  # indices of t
   X <- cbind(ylag, Xlags, PC)[anchors, , drop = FALSE]
   rownames(X) <- dates[anchors]
   y_target <- y[anchors + h]; names(y_target) <- dates[anchors + h]

--- a/ert.R
+++ b/ert.R
@@ -63,7 +63,12 @@ build_xy_paper <- function(dados, yname, h, p_y=4, x_lags=4, pc_fit) {
   PC <- as.matrix(X_t_scaled) %*% pc_fit$rotation[, 1:4, drop = FALSE]
   colnames(PC) <- paste0("PC", 1:4)
   maxdrop <- max(p_y, x_lags)
-  anchors <- maxdrop:(nrow(dados) - h)
+  last_anchor <- nrow(dados) - h
+  if (last_anchor < maxdrop) {
+    stop("Not enough history for horizon h=", h,
+         " (need anchor >= ", maxdrop, ", have last_anchor = ", last_anchor, ").")
+  }
+  anchors <- seq.int(maxdrop, last_anchor)
   X <- cbind(ylag, Xlags, PC)[anchors, , drop = FALSE]
   rownames(X) <- dates[anchors]
   y_target <- y[anchors + h]; names(y_target) <- dates[anchors + h]

--- a/lasso.R
+++ b/lasso.R
@@ -87,7 +87,12 @@ build_xy_paper <- function(dados, yname, h, p_y=4, x_lags=4, pc_fit) {
   
   # assemble design at anchor t; target is y_{t+h}
   maxdrop <- max(p_y, x_lags)
-  anchors <- maxdrop:(nrow(dados) - h)  # indices of t
+  last_anchor <- nrow(dados) - h
+  if (last_anchor < maxdrop) {
+    stop("Not enough history for horizon h=", h,
+         " (need anchor >= ", maxdrop, ", have last_anchor = ", last_anchor, ").")
+  }
+  anchors <- seq.int(maxdrop, last_anchor)  # indices of t
   X <- cbind(ylag, Xlags, PC)[anchors, , drop = FALSE]
   rownames(X) <- dates[anchors]
   

--- a/qRF.R
+++ b/qRF.R
@@ -63,7 +63,12 @@ build_xy_paper <- function(dados, yname, h, p_y=4, x_lags=4, pc_fit) {
   PC <- as.matrix(X_t_scaled) %*% pc_fit$rotation[, 1:4, drop = FALSE]
   colnames(PC) <- paste0("PC", 1:4)
   maxdrop <- max(p_y, x_lags)
-  anchors <- maxdrop:(nrow(dados) - h)
+  last_anchor <- nrow(dados) - h
+  if (last_anchor < maxdrop) {
+    stop("Not enough history for horizon h=", h,
+         " (need anchor >= ", maxdrop, ", have last_anchor = ", last_anchor, ").")
+  }
+  anchors <- seq.int(maxdrop, last_anchor)
   X <- cbind(ylag, Xlags, PC)[anchors, , drop = FALSE]
   rownames(X) <- dates[anchors]
   y_target <- y[anchors + h]; names(y_target) <- dates[anchors + h]

--- a/qert.R
+++ b/qert.R
@@ -57,7 +57,12 @@ build_xy_paper <- function(dados, yname, h, p_y=4, x_lags=4, pc_fit) {
   PC <- as.matrix(X_t_scaled) %*% pc_fit$rotation[, 1:4, drop = FALSE]
   colnames(PC) <- paste0("PC", 1:4)
   maxdrop <- max(p_y, x_lags)
-  anchors <- maxdrop:(nrow(dados) - h)
+  last_anchor <- nrow(dados) - h
+  if (last_anchor < maxdrop) {
+    stop("Not enough history for horizon h=", h,
+         " (need anchor >= ", maxdrop, ", have last_anchor = ", last_anchor, ").")
+  }
+  anchors <- seq.int(maxdrop, last_anchor)
   X <- cbind(ylag, Xlags, PC)[anchors, , drop = FALSE]
   rownames(X) <- dates[anchors]
   y_target <- y[anchors + h]; names(y_target) <- dates[anchors + h]

--- a/rf.R
+++ b/rf.R
@@ -70,7 +70,12 @@ build_xy_paper <- function(dados, yname, h, p_y=4, x_lags=4, pc_fit) {
   colnames(PC) <- paste0("PC", 1:4)
   
   maxdrop <- max(p_y, x_lags)
-  anchors <- maxdrop:(nrow(dados) - h)
+  last_anchor <- nrow(dados) - h
+  if (last_anchor < maxdrop) {
+    stop("Not enough history for horizon h=", h,
+         " (need anchor >= ", maxdrop, ", have last_anchor = ", last_anchor, ").")
+  }
+  anchors <- seq.int(maxdrop, last_anchor)
   X <- cbind(ylag, Xlags, PC)[anchors, , drop = FALSE]
   rownames(X) <- dates[anchors]
   y_target <- y[anchors + h]; names(y_target) <- dates[anchors + h]

--- a/rfols.R
+++ b/rfols.R
@@ -74,7 +74,12 @@ build_xy_paper <- function(dados, yname, h, p_y=4, x_lags=4, pc_fit) {
   colnames(PC) <- paste0("PC", 1:4)
   
   maxdrop <- max(p_y, x_lags)
-  anchors <- maxdrop:(nrow(dados) - h)  # indices of t
+  last_anchor <- nrow(dados) - h
+  if (last_anchor < maxdrop) {
+    stop("Not enough history for horizon h=", h,
+         " (need anchor >= ", maxdrop, ", have last_anchor = ", last_anchor, ").")
+  }
+  anchors <- seq.int(maxdrop, last_anchor)  # indices of t
   
   X <- cbind(ylag, Xlags, PC)[anchors, , drop = FALSE]
   rownames(X) <- dates[anchors]

--- a/ridge.R
+++ b/ridge.R
@@ -92,7 +92,12 @@ build_xy_paper <- function(dados, yname, h, p_y=4, x_lags=4, pc_fit) {
   colnames(PC) <- paste0("PC", 1:4)
   
   maxdrop <- max(p_y, x_lags)
-  anchors <- maxdrop:(nrow(dados) - h)  # indices of t
+  last_anchor <- nrow(dados) - h
+  if (last_anchor < maxdrop) {
+    stop("Not enough history for horizon h=", h,
+         " (need anchor >= ", maxdrop, ", have last_anchor = ", last_anchor, ").")
+  }
+  anchors <- seq.int(maxdrop, last_anchor)  # indices of t
   
   # >>> RE-ENABLE PCs here <<<
   X <- cbind(ylag, Xlags, PC)[anchors, , drop = FALSE]


### PR DESCRIPTION
## Summary
- add an explicit history check to `build_xy_paper()` across the forecasting scripts so horizons with insufficient observations stop early instead of generating invalid anchors
- switch anchor construction to `seq.int()` after the new guard so we never create descending sequences that would later index targets beyond the sample

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cabe7a4b1c832e8eb6a9921dfe7c70